### PR TITLE
feat: add --from-template flag to meteor create

### DIFF
--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -751,6 +751,7 @@ main.registerCommand({
     legacy: { type: Boolean },
     prototype: { type: Boolean },
     from: { type: String },
+    'from-template': { type: String },
   },
   pretty: false,
   catalogRefresh: new catalog.Refresh.Never()
@@ -915,6 +916,66 @@ main.registerCommand({
       "To create an example, simply",
       Console.command("'meteor create <app-name> --example <name>'")
     );
+    return 0;
+  }
+
+  if (options['from-template']) {
+    const template = options['from-template'];
+
+    // Accept "owner/repo" or "https://github.com/owner/repo"
+    let owner, repo;
+    const ghUrlMatch = template.match(
+      /^https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/
+    );
+    const shorthandMatch = template.match(/^([\w.-]+)\/([\w.-]+)$/);
+
+    if (ghUrlMatch) {
+      owner = ghUrlMatch[1];
+      repo = ghUrlMatch[2];
+    } else if (shorthandMatch) {
+      owner = shorthandMatch[1];
+      repo = shorthandMatch[2];
+    } else {
+      Console.error(
+        `Invalid template format: ${Console.command(template)}`
+      );
+      Console.error(
+        'Expected format: ' +
+        Console.command('owner/repo') +
+        ' or ' +
+        Console.command('https://github.com/owner/repo')
+      );
+      return 1;
+    }
+
+    // Use provided app name or default to the repo name
+    var appPathAsEntered = options.args[0] || repo;
+    var appPath = files.pathResolve(appPathAsEntered);
+
+    if (files.findAppDir(appPath)) {
+      Console.error(
+        "You can't create a Meteor project inside another Meteor project."
+      );
+      return 1;
+    }
+
+    Console.info(`Verifying that ${owner}/${repo} is a Meteor project...`);
+    const { exists, skipped } = await verifyGitHubMeteorRepo(owner, repo);
+
+    if (!exists) {
+      Console.error(
+        `The repository ${Console.command(`${owner}/${repo}`)} does not ` +
+        `appear to be a Meteor project (no .meteor folder found).`
+      );
+      return 1;
+    }
+
+    if (!skipped) {
+      Console.info(`Verified! .meteor folder found in ${owner}/${repo}.`);
+    }
+
+    const url = `https://github.com/${owner}/${repo}`;
+    await setupExampleByURL(url);
     return 0;
   }
 
@@ -1152,10 +1213,49 @@ main.registerCommand({
   }
 
   /**
+   * Verify that a GitHub repository contains a .meteor folder.
+   * @param {string} owner - GitHub username or org
+   * @param {string} repo - Repository name
+   * @returns {Promise<{exists: boolean, skipped: boolean}>}
+   */
+  async function verifyGitHubMeteorRepo(owner, repo) {
+    const apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/.meteor`;
+    try {
+      const response = await httpHelpers.request({
+        url: apiUrl,
+        method: 'GET',
+        headers: {
+          'User-Agent': 'MeteorTool',
+          'Accept': 'application/vnd.github.v3+json',
+        },
+      });
+      const statusCode = response.response.statusCode;
+      if (statusCode === 200) {
+        return { exists: true, skipped: false };
+      }
+      if (statusCode === 404) {
+        return { exists: false, skipped: false };
+      }
+      // Rate limited or other issue — warn but don't block
+      Console.warn(
+        `Could not verify .meteor folder (HTTP ${statusCode}). ` +
+        `Proceeding with clone anyway.`
+      );
+      return { exists: true, skipped: true };
+    } catch (e) {
+      Console.warn(
+        `Could not verify .meteor folder: ${e.message}. ` +
+        `Proceeding with clone anyway.`
+      );
+      return { exists: true, skipped: true };
+    }
+  }
+
+  /**
    *
    * @param {string} url
    */
-  const setupExampleByURL = async (url) => {
+  async function setupExampleByURL(url) {
     const [ok, err] = await bash`git --version`;
     if (err) throw new Error("git is not installed");
     const isWindows = process.platform === "win32";
@@ -1174,7 +1274,7 @@ main.registerCommand({
     // remove .git folder from the example
     await files.rm_recursive_async(files.pathJoin(appPath, ".git"));
     await setupMessages();
-  };
+  }
 
   if (options.example) {
     const [json, err] = await getExamplesJSON();

--- a/tools/tests/create.js
+++ b/tools/tests/create.js
@@ -50,6 +50,72 @@ selftest.define("create main", async function () {
   await run.expectExit(0);
 });
 
+selftest.define("create --from-template invalid format", async function () {
+  var s = new Sandbox({ warehouse: SIMPLE_WAREHOUSE });
+  await s.init();
+
+  // Invalid format (no slash)
+  var run = s.run("create", "--from-template", "invalidformat", "testapp");
+  await run.matchErr("Invalid template format");
+  await run.matchErr("owner/repo");
+  await run.expectExit(1);
+});
+
+selftest.define("create --from-template non-meteor repo", ["net"], async function () {
+  var s = new Sandbox({ warehouse: SIMPLE_WAREHOUSE });
+  await s.init();
+
+  // A well-known repo on GitHub that does NOT have a .meteor folder
+  var run = s.run("create", "--from-template", "expressjs/express", "testapp");
+  run.waitSecs(30);
+  await run.match("Verifying");
+  await run.matchErr("does not appear to be a Meteor project");
+  await run.expectExit(1);
+});
+
+selftest.define("create --from-template success", ["net", "slow"], async function () {
+  var s = new Sandbox({ warehouse: SIMPLE_WAREHOUSE });
+  await s.init();
+
+  // Use one of Meteor's own skeleton repos (small, known to have .meteor)
+  var run = s.run("create", "--from-template", "meteor/skel-react", "myapp");
+  run.waitSecs(60);
+  await run.match("Verifying");
+  await run.match("Verified");
+  await run.match("Created a new Meteor app in 'myapp'");
+  await run.expectExit(0);
+
+  // Verify .meteor folder exists in the created app
+  s.cd("myapp");
+  const packages = s.read(".meteor/packages");
+  if (!packages) {
+    selftest.fail("Expected .meteor/packages to exist in cloned template");
+  }
+});
+
+selftest.define("create --from-template full github url", async function () {
+  var s = new Sandbox({ warehouse: SIMPLE_WAREHOUSE });
+  await s.init();
+
+  // Invalid full URL (not github)
+  var run = s.run("create", "--from-template", "https://gitlab.com/foo/bar", "testapp");
+  await run.matchErr("Invalid template format");
+  await run.expectExit(1);
+});
+
+selftest.define("create --from-template defaults app name to repo", ["net", "slow"], async function () {
+  var s = new Sandbox({ warehouse: SIMPLE_WAREHOUSE });
+  await s.init();
+
+  // No app name argument — should default to the repo name
+  var run = s.run("create", "--from-template", "meteor/skel-react");
+  run.waitSecs(60);
+  await run.match("Verifying");
+  await run.match("Verified");
+  await run.match("Created a new Meteor app in 'skel-react'");
+  await run.expectExit(0);
+});
+
 // TODO: Enable once rspack is published for the first time
 // Also, the new modern test suite covers more than this test.
 // This test may not work, as rspack relies on project npm dependencies


### PR DESCRIPTION
## Summary

Add a new `--from-template` option to `meteor create` that allows creating a project from any GitHub repository that contains a `.meteor` folder.

## Usage

```bash
# Shorthand format
meteor create my-app --from-template wreiske/meteor-react-tailwind-prettier-starter

# Full GitHub URL
meteor create my-app --from-template https://github.com/wreiske/meteor-react-tailwind-prettier-starter

# Omit app name — defaults to repo name
meteor create --from-template wreiske/meteor-react-tailwind-prettier-starter
```

## How it works

1. **Parses** the template argument — accepts `owner/repo` shorthand or full `https://github.com/owner/repo` URLs
2. **Verifies** the repo contains a `.meteor` folder via the GitHub Contents API (`GET /repos/{owner}/{repo}/contents/.meteor`) — no need to clone the entire repo first
3. **Clones** the repository using the existing `setupExampleByURL` infrastructure (git clone, `.git` removal, project setup)
4. **Handles edge cases gracefully**:
   - Invalid format → clear error with expected format
   - Repo doesn't exist or no `.meteor` folder → clear error message
   - GitHub API rate limit or network issues → warns but proceeds with clone anyway

## Why `--from-template` instead of extending `--from`?

`--from` accepts arbitrary git URLs (including non-GitHub) and performs no validation. `--from-template` is specifically designed for GitHub repos with `.meteor` folder verification — a different contract that provides safety and better UX.

## Tests

Added 5 self-tests in `tools/tests/create.js`:
- **Invalid format** — rejects input without `owner/repo` pattern
- **Non-Meteor repo** — rejects repos without `.meteor` folder (e.g., `expressjs/express`)
- **Successful creation** — clones and sets up from `meteor/skel-react`
- **Non-GitHub URL** — rejects GitLab/other URLs
- **Default app name** — defaults to repo name when no app name argument provided

## Files changed

- `tools/cli/commands.js` — Added `--from-template` option, `verifyGitHubMeteorRepo()` helper, and handler logic
- `tools/tests/create.js` — Added 5 self-tests for the new flag